### PR TITLE
chore(ci): Add script to generate project programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "workspaces": [
     "packages/*"
   ],
+  "type": "module",
   "scripts": {
     "dev": "lerna run dev --parallel --stream",
     "dev:ssl": "lerna run dev:ssl --parallel --stream",

--- a/packages/create-common/src/create.ts
+++ b/packages/create-common/src/create.ts
@@ -188,7 +188,7 @@ ${green('✔')} ${bold('Target directory')} ${dim('…')} ${projectDir}
  * @privateRemarks This function must be able to run in CI without user
  *  interaction, and cannot prompt for input.
  */
-async function createProjectFromConfig(
+export async function createProjectFromConfig(
   templateDir: string,
   projectDir: string,
   config: ProjectConfig,

--- a/scripts/generate-ci-project.js
+++ b/scripts/generate-ci-project.js
@@ -1,0 +1,31 @@
+import { createProjectFromConfig } from '@carto/create-common';
+import { resolve } from 'node:path';
+
+/**
+ * Helper script to generate test projects in CI. Given a template/framework
+ * name, a target project path, and an access token, creates a new project
+ * (without user interaction with the usual CLI) in that directory.
+ */
+
+const [_execPath, _scriptPath, template, projectPath, accessToken] =
+  process.argv;
+
+const TemplatePath = {
+  angular: './packages/create-angular',
+  react: './packages/create-react',
+  vue: './packages/create-vue',
+};
+
+if (!TemplatePath[template]) {
+  throw new Error(`Unexpected template, "${template}"`);
+}
+
+await createProjectFromConfig(
+  resolve(process.cwd(), TemplatePath[template]),
+  resolve(process.cwd(), projectPath),
+  {
+    title: `CI Test (${template})`,
+    authEnabled: false,
+    accessToken,
+  },
+);


### PR DESCRIPTION
Usage:

```bash
node scripts/generate-ci-project.js [ angular | react | vue ] <project-dir> <access-token>
```