### PR TITLE
chore(deps): Set up dependabot update groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,6 @@ updates:
           - 'vue-*'
       dev-dependencies:
         dependency-type: 'development'
+    ignore:
+      # Angular template requires TypeScript <5.6.
+      - dependency-name: "typescript"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,25 @@ updates:
       interval: 'weekly'
     reviewers:
       - 'CartoDB/frontend-team'
-
+    groups:
+      deck-gl:
+        patterns:
+          - '@deck.gl/*'
+      luma-gl:
+        patterns:
+          - '@luma.gl/*'
+      angular:
+        patterns:
+          - '@angular/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-*'
+          - '@types/react'
+          - '@types/react-*'
+      vue:
+        patterns:
+          - 'vue'
+          - 'vue-*'
+      dev-dependencies:
+        dependency-type: 'development'


### PR DESCRIPTION
Adds dependency update groups for:

- deckgl
- lumagl
- angular
- react
- vue
- devDependencies

Ignores 'typescript' for automated updates - the Angular template requires TypeScript <5.6.