### PR TITLE
chore(deps): Add more dependencies to Angular update group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       angular:
         patterns:
           - '@angular/*'
+          - '@angular-devkit/*'
       react:
         patterns:
           - 'react'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
         patterns:
           - '@angular/*'
           - '@angular-devkit/*'
+          - 'zone.js'
+          - 'rxjs'
       react:
         patterns:
           - 'react'


### PR DESCRIPTION
Some update PRs failing (#56, #54) at least in part because the angular-related updates got split across multiple groups. Attempting to fix the groups here.