### PR TITLE
chore(ci): Assign appdev team for dependabot reviews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     reviewers:
-      - 'CartoDB/frontend-team'
+      - 'CartoDB/app-dev-builder-team'
     groups:
       deck-gl:
         patterns:


### PR DESCRIPTION
Changes:

- Dependabot will ping appdev, not frontend-team, for update reviews
- Non-security updates will be monthly, not weekly