### PR TITLE
chore(release): v0.1.5

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.5-alpha.0",
-  "packages": [
-    "packages/*"
-  ],
+  "version": "0.1.5",
+  "packages": ["packages/*"],
   "npmClient": "yarn",
   "command": {
     "version": {

--- a/packages/create-angular/package.json
+++ b/packages/create-angular/package.json
@@ -4,7 +4,7 @@
   "repository": "github:CartoDB/carto-app-templates",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "license": "MIT",
-  "version": "0.1.5-alpha.0",
+  "version": "0.1.5",
   "type": "module",
   "bin": "./scripts/create.js",
   "scripts": {

--- a/packages/create-common/package.json
+++ b/packages/create-common/package.json
@@ -2,7 +2,7 @@
   "name": "@carto/create-common",
   "packageManager": "yarn@4.2.2",
   "author": "Don McCurdy <donmccurdy@carto.com>",
-  "version": "0.1.5-alpha.0",
+  "version": "0.1.5",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/packages/create-react/package.json
+++ b/packages/create-react/package.json
@@ -4,7 +4,7 @@
   "repository": "github:CartoDB/carto-app-templates",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "license": "MIT",
-  "version": "0.1.5-alpha.0",
+  "version": "0.1.5",
   "type": "module",
   "bin": "./scripts/create.js",
   "scripts": {

--- a/packages/create-vue/package.json
+++ b/packages/create-vue/package.json
@@ -4,7 +4,7 @@
   "repository": "github:CartoDB/carto-app-templates",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "license": "MIT",
-  "version": "0.1.5-alpha.0",
+  "version": "0.1.5",
   "type": "module",
   "bin": "./scripts/create.js",
   "scripts": {


### PR DESCRIPTION
Followup release for https://github.com/CartoDB/carto-app-templates/pull/77.